### PR TITLE
Meta: Add common ladybird libraries and core library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 list(APPEND CMAKE_MODULE_PATH "$ENV{SERENITY_SOURCE_DIR}/Meta/CMake")
 include(Meta/CMake/Lagom.cmake)
@@ -25,5 +26,16 @@ add_executable(Ladybird MACOSX_BUNDLE
 )
 
 target_compile_options(Ladybird PRIVATE -DAK_DONT_REPLACE_STD -DUSING_AK_GLOBALLY=0 -fobjc-arc)
-target_link_libraries(Ladybird PRIVATE LibCore ${COCOA_LIBRARY})
-target_include_directories(Ladybird PRIVATE .)
+target_link_libraries(Ladybird PRIVATE ${COCOA_LIBRARY}
+   LibCore
+   LibFileSystem
+   LibGfx
+   LibGUI
+   LibIPC
+   LibJS
+   LibWebView
+   LibProtocol
+   LibSQL
+   ladybird
+)
+

--- a/Meta/CMake/Lagom.cmake
+++ b/Meta/CMake/Lagom.cmake
@@ -1,4 +1,6 @@
 set(BUILD_LAGOM ON CACHE INTERNAL "Build all Lagom targets")
+set(ENABLE_LAGOM_LADYBIRD ON CACHE INTERNAL "Build ladybird targets")
+set(ENABLE_QT OFF CACHE INTERNAL "Enable Qt GUI for ladybird")
 
 set(LAGOM_SOURCE_DIR "$ENV{SERENITY_SOURCE_DIR}/Meta/Lagom")
 set(LAGOM_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/Lagom")


### PR DESCRIPTION
This adds the common CookieJar, History and helper process components to the Cocoa app.

This will work once we add a macOS non-Qt Audio backend :D